### PR TITLE
Improve array merging capabilities

### DIFF
--- a/lib/puppet/type/rbac_role.rb
+++ b/lib/puppet/type/rbac_role.rb
@@ -12,14 +12,44 @@ Puppet::Type.newtype(:rbac_role) do
 
   newproperty(:permissions, :array_matching =>:all) do
     desc 'Array of permission objects for the role'
+
+    def insync?(is)
+      # The current value may be nil and we don't
+      # want to call sort on it so make sure we have arrays
+      if is.is_a?(Array) and @should.is_a?(Array)
+        is.sort == @should.sort
+      else
+        is == @should
+      end
+    end
   end
 
   newproperty(:user_ids, :array_matching =>:all) do
     desc 'Array of UUIDs of users assigned to the role'
+
+    def insync?(is)
+      # The current value may be nil and we don't
+      # want to call sort on it so make sure we have arrays
+      if is.is_a?(Array) and @should.is_a?(Array)
+        is.sort == @should.sort
+      else
+        is == @should
+      end
+    end
   end
 
   newproperty(:group_ids, :array_matching =>:all) do
     desc 'Array of UUIDs of groups assigned to the role'
+
+    def insync?(is)
+      # The current value may be nil and we don't
+      # want to call sort on it so make sure we have arrays
+      if is.is_a?(Array) and @should.is_a?(Array)
+        is.sort == @should.sort
+      else
+        is == @should
+      end
+    end
   end
 
   newproperty(:id) do

--- a/lib/puppet/type/rbac_role.rb
+++ b/lib/puppet/type/rbac_role.rb
@@ -17,7 +17,14 @@ Puppet::Type.newtype(:rbac_role) do
       # The current value may be nil and we don't
       # want to call sort on it so make sure we have arrays
       if is.is_a?(Array) and @should.is_a?(Array)
-        is.sort == @should.sort
+        # if all the elements are hashes then we can compare them using this
+        # nice method. If  not we are going to have to rely on ==
+        if (is + @should).all? { |x| x.is_a?(Hash) }
+          diff = (is - @should) + (@should - is)
+          diff.empty?
+        else
+          is.sort == @should.sort
+        end
       else
         is == @should
       end


### PR DESCRIPTION
In a future release of Puppet, the order in which the RBAC API reports the permissions of a group will change. This means that if anyone is using this module their group it will continually try to enforce the resource even though it is already correct as it sees array order as important. This PR ensures that the order of any of the array parameters of the Group type are not considered when matching for equality