### PR TITLE
Update module to pe-rbac api v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ Gemfile.lock
 .bundle/
 spec/fixtures/
 .yardoc
+vendor/
+.ruby-version
+*.swp

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+v0.1.0
+  * BREAKING CHANGE: Move to the v2 PE RBAC API. (j0sh3rs)
+  * Add support for optional ldap validation and Display Name (j0sh3rs)
+
 v0.0.10
   * Add support for user names instead of just UUIDs (dylanratcliffe)
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ rbac_role { 'Viewers':
 }
 
 rbac_group { 'admins':
-  ensure => 'present',
-  roles  => ['Administrators'],
+  ensure       => 'present',
+  roles        => ['Administrators'],
+  display_name => 'Global Admins',
+  validate     => false
 }
 
 ```

--- a/lib/puppet/provider/rbac_api.rb
+++ b/lib/puppet/provider/rbac_api.rb
@@ -30,7 +30,7 @@ class Puppet::Provider::Rbac_api < Puppet::Provider
     https
   end
 
-  def self.make_uri(path, prefix = '/rbac-api/v1')
+  def self.make_uri(path, prefix = '/rbac-api/v2')
     uri = URI.parse("https://#{@config['server']}:#{@config['port']}#{prefix}#{path}")
     uri
   end

--- a/lib/puppet/provider/rbac_group/ruby.rb
+++ b/lib/puppet/provider/rbac_group/ruby.rb
@@ -51,8 +51,10 @@ Puppet::Type.type(:rbac_group).provide(:ruby, :parent => Puppet::Provider::Rbac_
     role_ids = resource['roles'].map { |name| $roles.key(name) }
 
     group = {
-      'login'    => resource[:name],
-      'role_ids' => role_ids,
+      'login'        => resource[:name],
+      'role_ids'     => role_ids,
+      'display_name' => display_name || resource[:name]
+      'validate'     => validate || false,
     }
     Puppet::Provider::Rbac_api::post_response('/groups', group)
 

--- a/lib/puppet/type/rbac_group.rb
+++ b/lib/puppet/type/rbac_group.rb
@@ -31,4 +31,12 @@ Puppet::Type.newtype(:rbac_group) do
     desc 'The read-only ID of the group'
   end
 
+  newproperty(:display_name) do
+    desc '[Optional] The Display Name to show in PE Console. Default to role-name'
+  end
+
+  newproperty(:validate) do
+    desc '[Optional] Validate the rbac_group against the LDAP configuration. Default: false'
+  end
+
 end

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
     }
   ],
   "name": "pltraining-rbac",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "author": "pltraining",
   "summary": "Exposes Puppet Enterprise Console RBAC APIs to the Puppet DSL",
   "license": "Apache 2.0",

--- a/tests/groups.pp
+++ b/tests/groups.pp
@@ -1,4 +1,5 @@
 rbac_group { 'contractors':
-  ensure => 'present',
-  roles  => ['Viewers','Operators'],
+  ensure   => 'present',
+  roles    => ['Viewers','Operators'],
+  validate => false,
 }


### PR DESCRIPTION
This PR is expected to do three things:
* Move the default behavior to using the pe-rbac v2 api
* Add support for the optional `validate` param for group mappings
* Add support for the optional 'display_name' param for group mappings